### PR TITLE
Add demo UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.log
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# LandVision-Pro
+# LandVision Pro
+
+This repository contains an initial scaffold for the YardVision Pro backend and documentation.
+
+## Running the API
+
+Install dependencies and start the development server with Uvicorn:
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+Alternatively, you may run the small helper module:
+
+```bash
+python -m backend.run --host 0.0.0.0 --port 8000
+```
+
+Both approaches serve the FastAPI app (use `--port` to change the port).
+
+### Accessing the Demo UI
+
+The repository includes a very small front end that interacts with the API. After starting the server, open `http://localhost:8000/ui/` in your browser to try it out.
+
+### Available Endpoints
+
+- `POST /v1/design-jobs` – submit a design request
+- `GET /v1/design-jobs/{job_id}` – check job status
+- `POST /v1/credits/purchase` – add credits to a tenant wallet
+- `POST /v1/credits/deduct` – consume credits
+- `GET /v1/rate-card?tenant_id=...` – fetch a tenant's rate card

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,109 @@
+import asyncio
+import uuid
+
+from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from enum import Enum
+from typing import Dict, List
+import os
+
+app = FastAPI(title="YardVision Pro API", version="0.1")
+
+# Serve the simple frontend for demonstration purposes
+frontend_dir = os.path.join(os.path.dirname(__file__), "..", "frontend")
+if os.path.isdir(frontend_dir):
+    app.mount("/ui", StaticFiles(directory=frontend_dir, html=True), name="ui")
+
+class JobStatus(str, Enum):
+    queued = "QUEUED"
+    running = "RUNNING"
+    complete = "COMPLETE"
+    error = "ERROR"
+
+class DesignJobRequest(BaseModel):
+    project_id: str
+    preview_only: bool = False
+
+class CreditsDeductRequest(BaseModel):
+    tenant_id: str
+    amount: int
+
+class CreditsPurchaseRequest(BaseModel):
+    tenant_id: str
+    plan_id: str
+
+class RateCardItem(BaseModel):
+    id: str
+    item_type: str
+    unit: str
+    base_cost: float
+    labor_hours: float
+    category: str
+
+fake_jobs: Dict[str, JobStatus] = {}
+credit_wallets: Dict[str, int] = {}
+rate_card_items: Dict[str, List[RateCardItem]] = {
+    "default": [
+        RateCardItem(
+            id="plant_a",
+            item_type="plant",
+            unit="each",
+            base_cost=10.0,
+            labor_hours=0.5,
+            category="Standard Plant",
+        )
+    ]
+}
+
+credit_plans = {
+    "starter": 1000,
+    "pro": 4000,
+    "agency": 10000,
+}
+
+async def _process_job(job_id: str):
+    fake_jobs[job_id] = JobStatus.running
+    await asyncio.sleep(1)
+    fake_jobs[job_id] = JobStatus.complete
+
+
+@app.post("/v1/design-jobs")
+def create_design_job(req: DesignJobRequest, background_tasks: BackgroundTasks):
+    job_id = str(uuid.uuid4())
+    fake_jobs[job_id] = JobStatus.queued
+    background_tasks.add_task(_process_job, job_id)
+    return {"job_id": job_id}
+
+@app.get("/v1/design-jobs/{job_id}")
+def get_design_job(job_id: str):
+    status = fake_jobs.get(job_id)
+    if not status:
+        raise HTTPException(status_code=404, detail="job not found")
+    return {"job_id": job_id, "status": status}
+
+@app.post("/v1/credits/deduct")
+def deduct_credits(req: CreditsDeductRequest):
+    balance = credit_wallets.get(req.tenant_id, 0)
+    if req.amount > balance:
+        raise HTTPException(status_code=400, detail="insufficient credits")
+    credit_wallets[req.tenant_id] = balance - req.amount
+    return {"tenant_id": req.tenant_id, "balance": credit_wallets[req.tenant_id]}
+
+
+@app.post("/v1/credits/purchase")
+def purchase_credits(req: CreditsPurchaseRequest):
+    credits = credit_plans.get(req.plan_id)
+    if not credits:
+        raise HTTPException(status_code=404, detail="plan not found")
+    credit_wallets[req.tenant_id] = credit_wallets.get(req.tenant_id, 0) + credits
+    return {
+        "tenant_id": req.tenant_id,
+        "balance": credit_wallets[req.tenant_id],
+        "session_url": f"https://example.com/pay/{req.plan_id}",
+    }
+
+@app.get("/v1/rate-card")
+def get_rate_card(tenant_id: str):
+    items = rate_card_items.get(tenant_id) or rate_card_items["default"]
+    return {"tenant_id": tenant_id, "items": [item.dict() for item in items]}

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,12 @@
+import uvicorn
+
+if __name__ == '__main__':
+    # Avoid reload=True to prevent multiprocessing issues in containers
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run YardVision Pro API")
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=8000)
+    args = parser.parse_args()
+
+    uvicorn.run('backend.main:app', host=args.host, port=args.port)

--- a/docs/PRD_v3.md
+++ b/docs/PRD_v3.md
@@ -1,0 +1,389 @@
+# YardVision Pro – Coding-Ready PRD (v3.0)
+
+**Scope note** – Product will launch only in the continental U S outside California; CCPA/GDPR requirements have been removed. General best-practice privacy, security, and data deletion controls remain.
+
+⸻
+
+## 1. Purpose & Strategic Objectives
+
+| ID  | Objective                              | 12‑Mo KPI                                                   |
+| --- | -------------------------------------- | ----------------------------------------------------------- |
+| O‑1 | Shorten landscaper sales cycle         | ‑35 % avg. days from site visit → signed contract           |
+| O‑2 | Raise proposal win rate                | +25 % (baseline confirmed at 20 % via pilot)                |
+| O‑3 | Achieve profitable SaaS unit economics | Gross margin ≥ 65 %; CAC payback ≤ 9 mo                     |
+| O‑4 | Build defensible data asset            | ≥ 50 k confirmed‑installed designs feeding model retraining |
+| O‑5 | Expand to five Sun‑Belt metros         | DFW → Houston → Phoenix → Tampa → Atlanta by M12            |
+
+⸻
+
+## 2. Market Context (abridged)
+
+* TAM (Sun‑Belt 5 metros): ≈ 17 k firms, $27 B rev.
+* Gap: Existing CRMs (Jobber, LMN) lack automated photoreal renders, risk scoring, and credit‑based AI usage.
+
+⸻
+
+## 3. Personas
+
+| Persona    | Core Goals                           | Key Pain                             |
+| ---------- | ------------------------------------ | ------------------------------------ |
+| Crew Lead  | Capture site data once, no paperwork | Juggling phone photos + scribbles    |
+| Estimator  | Quote fast & accurately              | Manual take‑offs, excel errors       |
+| Owner / GM | Grow revenue, control margin         | No visibility to funnel, weak upsell |
+| Admin      | Manage users, prices, branding       | N/A today                            |
+| Homeowner  | Visualize result & price             | Fear of poor plant survival          |
+
+⸻
+
+## 4. End‑to‑End Workflows (delta‑enhanced)
+
+### 4.1 Capture (Mobile PWA / React Native wrapper)
+
+1. **New Project** → auto‑tags GPS, date, crew ID.
+2. **Photo sweep**: min 6 photos; app enforces 30° overlap for photogrammetry.
+3. **Scale reference**: user scans a YardVision QR‑marker (12 in) or inputs a baseline dimension.
+4. **Sketch layer** (Red = remove, Green = add, Blue = hardscape).
+5. **Voice note** → text; NLP tags species.
+6. **Offline queue** capped 250 MB; syncs on connectivity.
+
+### 4.2 AI Design Job (async)
+
+* `POST /v1/design-jobs` returns `job_id`.
+* Pipeline: Annotation → Plant‑Detect (YOLOv8‑Landscape) → Design Grammar engine (see §10) → SDXL preview (1024²) in ≤ 45 s P95 → HD render (4096²) queued; average 120 s.
+* Risk Engine pulls climate/soil zone (Köppen API, SoilGrids) and computes severity.
+* Upsell Generator produces 3 high‑margin concepts; preview renders on demand.
+
+### 4.3 Proposal & Acceptance
+
+* Estimator adjusts BOM, labor hrs, overhead multipliers.
+* “Publish Proposal” → PDFs + interactive microsite (Next.js static w/ client‑side toggles).
+* Status webhooks (signed HMAC) to Jobber / LMN; accepted jobs push final design to **Confirm & Finalize** step (crew marks actual install).
+* Final design + outcome feed back into training store.
+
+⸻
+
+## 5. Functional Requirements (selected)
+
+| ID       | Detail                                                                                     |
+| -------- | ------------------------------------------------------------------------------------------ |
+| F‑CAP‑03 | Photogrammetry engine must infer ±5 % accuracy on distances ≤ 40 ft using scale reference. |
+| F‑DES‑01 | Design Grammar engine must respect spacing, layer, color‑contrast rules (see appendix).    |
+| F‑REN‑03 | HD render P95 ≤ 180 s under 500 concurrent jobs (GPU auto‑scale).                          |
+| F‑RSK‑03 | Risk Engine pluggable zones; must support any US zip code south of USDA 6.                 |
+| F‑ADM‑01 | Admin portal: user CRUD, brand settings, rate‑card editor, credit wallet.                  |
+
+⸻
+
+## 6. Non‑Functional Requirements
+
+| Category      | Requirement                                                                               |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| Performance   | Non‑render API P95 ≤ 300 ms; design job queue throughput ≥ 3 k/hr.                        |
+| Availability  | 99.7 % monthly.                                                                           |
+| Security      | SSO (O365/Google), TLS 1.3, row‑level tenant isolation; signed JWT (24 h life) + refresh. |
+| Privacy       | Photos stored 365 d by default; tenant admin may purge at any time.                       |
+| Compliance    | SOC 2 Type I by M9, Type II by M15.                                                       |
+| Accessibility | WCAG 2.1 AA.                                                                              |
+| Localization  | ES‑MX UI in M6.                                                                           |
+
+⸻
+
+## 7. System Architecture (updated)
+
+```mermaid
+flowchart TD
+  subgraph Mobile
+    A[React‑Native / PWA]
+  end
+  A -->|REST| B[API Gateway]
+  B --> C[Capture Service]
+  B --> D[Design Job Queue (SQS)]
+  D --> E[Worker Fleet – GPU (SDXL, YOLO)]
+  E --> F[Design Grammar Engine]
+  F --> G[Risk Engine]
+  F --> H[Upsell GPT‑4o]
+  H --> I[Cost Estimator]
+  G & I --> J[(PostgreSQL + S3)]
+  B --> K[Proposal Service]
+  K --> L[PDF / Microsite Builder]
+  L --> S3
+  B --> M[Admin Service]
+  J -->|CDC| N[Model Registry (MLflow)]
+  N --> O[Training Pipeline (ECS Batch)]
+  O --> P[Model Versions]
+  P --> E
+  G -->|events| Q[(Kafka)]
+  Q --> Grafana & Metabase
+```
+
+* **GPU pool auto‑scale** via AWS AutoScaling (g5.xlarge baseline 2 → 20).
+* **Observability**: OpenTelemetry traces, Grafana Cloud; business funnel metrics via Kafka stream.
+* **Deployment**: GitHub Actions → ECR; Blue‑Green on ECS; IaC with Terraform.
+
+⸻
+
+## 8. Data Model (additions)
+
+| Table                         | Key Columns                                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `users`                       | id, tenant_id, name, email, role ENUM('admin','estimator','crew'), pw_hash, status |
+| `credit_wallets`              | tenant_id, balance_int (AI credits), updated_at                                   |
+| `rate_card_items`             | id, tenant_id, item_type, unit, base_cost, labor_hours, category                 |
+| `audit_log`                   | id, user_id, action, meta_json, ts                                                 |
+| *(all prior tables retained)* |                                                                                      |
+
+⸻
+
+## 9. API Spec (delta)
+
+| Method | Endpoint                  | Params                           | Notes                                      |
+| ------ | ------------------------- | -------------------------------- | ------------------------------------------ |
+| POST   | /v1/design‑jobs           | project_id, preview_only(bool) | Returns job_id                            |
+| GET    | /v1/design‑jobs/{job_id} | –                                | QUEUED / RUNNING / COMPLETE / ERROR + urls |
+| POST   | /v1/credits/purchase      | plan_id                         | Stripe checkout session                    |
+| POST   | /v1/credits/deduct        | tenant_id, amount               | Idempotent; called by Design Service       |
+| GET    | /v1/rate‑card             | tenant_id                       | Structured rates                           |
+
+⸻
+
+## 10. AI & ML Components
+
+| Component       | Model                             | Metric                | Ops                                    |
+| --------------- | --------------------------------- | --------------------- | -------------------------------------- |
+| Plant Detect    | YOLOv8‑Landscape                  | mAP@0.5 ≥ 0.88       | Auto‑retrain monthly on flagged errors |
+| Design Grammar  | Rule+GNN hybrid                   | Human QA score ≥ 90 % | Versioned in MLflow; A/B rollout       |
+| Risk Classifier | GBM + DistilBERT                  | F1 ≥ 0.80             | Drift monitor (KS‑stat > 0.1)          |
+| Upsell LLM      | GPT‑4o w/ system prompt v1        | Acceptance ≥ 90 %     | RLHF feedback loop                     |
+| Cost Estimator  | Linear labor model + margin rules | ±8 % vs. actuals      | Refit quarterly                        |
+
+⸻
+
+## 11. Security & Privacy
+
+* **AuthN**: JWT + refresh; revoke via Redis blacklist.
+* **AuthZ**: RBAC; signed HMAC on outgoing webhooks.
+* **PII**: Names/emails AES‑256 at rest.
+* **Content Safety**: AWS Rekognition + C2PA watermark on all renders.
+* **Disaster Recovery**: RDS multi‑AZ, 15‑min RPO; S3 cross‑region replicate (us‑east‑2).
+
+⸻
+
+## 12. Analytics & Telemetry
+
+| Metric                | Source                                       | Tool     |
+| --------------------- | -------------------------------------------- | -------- |
+| Render P95            | GPU worker logs                              | Grafana  |
+| Avg. quote time       | event diff (PROJECT_CREATED→PROPOSAL_SENT) | Metabase |
+| Win‑rate uplift       | proposals + Jobber webhook                   | Redash   |
+| Credits burn / tenant | `credit_wallets`                             | Grafana  |
+
+⸻
+
+## 13. Testing & QA
+
+* **Unit** ≥ 90 % on parsers, cost, risk.
+* **E2E** Cypress: capture → accepted job.
+* **Load** k6: 1 MB photo upload 300 rps; design job queue spike 1 k concurrent.
+* **AI regression**: synthetic benchmark each build; manual audit 200 renders/week (< 5 % error).
+* **Security**: OWASP ZAP; Snyk CVE monitor.
+
+⸻
+
+## 14. Rollout & Milestones (quarters)
+
+Q1 | Capture app GA, Design preview, credit billing
+Q2 | HD renders, Risk Engine (multi‑zone), Admin portal, Houston launch
+Q3 | Upsell engine, Jobber/LMN live sync, Phoenix & Tampa
+Q4 | Marketplace (suppliers), Atlanta, SOC‑2 Type I, cost estimator v2
+
+⸻
+
+## 15. Pricing & Packaging (credit‑based)
+
+| Plan                                                                             | Monthly | Included Credits | Seats | Notes                                 |
+| -------------------------------------------------------------------------------- | ------- | ---------------- | ----- | ------------------------------------- |
+| Starter                                                                          | $99    | 1 000            | 2     | ~25 HD renders + proposals           |
+| Pro                                                                              | $249   | 4 000            | 10    | Risk & Upsell, CRM sync               |
+| Agency                                                                           | $499   | 10 000           | 30    | API access, multi‑brand, priority GPU |
+| Overage: buy credit packs @ $0.035/credit (internal cost $0.02). Annual –10 %. |         |                  |       |                                       |
+
+*1 HD render = 40 credits; SD preview = 10; Upsell quick render = 20.*
+
+⸻
+
+## 16. Risks & Mitigations (top)
+
+| Risk                      | Impact         | Mitigation                                               |
+| ------------------------- | -------------- | -------------------------------------------------------- |
+| API price hikes           | Margin erosion | Credits buffer + provider redundancy; local SDXL         |
+| GPU shortage spring rush  | Queue delays   | Reserved GPU pool + spot burst                           |
+| Tech‑averse crews         | Low adoption   | Guided first‑run, stylus kit, live hotline               |
+| Design errors kill plants | Refunds        | Confidence scores, mandatory human review if risk = high |
+
+⸻
+
+## 17. Glossary (delta)
+
+* **Credit** – Internal unit (~$0.035) consumed per AI operation.
+* **Design Grammar** – Rule/GNN engine encoding landscape design principles.
+* **Confirm & Finalize** – Post‑install step supplying ground‑truth for retraining.
+
+⸻
+
+Appendix added below. This version is formatted and ready to be embedded in the final PRD (v3.0):
+
+---
+
+## **Appendix A: Design Grammar v1.0**
+
+### **Purpose**
+
+The Design Grammar Engine transforms sketched user intent into aesthetically cohesive, horticulturally sound landscape layouts. It enforces foundational rules, aesthetic principles, and leverages a GNN for final refinement.
+
+---
+
+### **1. Data Prerequisites**
+
+The `plant_catalog` must contain:
+
+* `growth_habit`: ENUM('clumping', 'spreading', 'upright', 'vining', 'mounding')
+* `height_class`: ENUM('groundcover', 'short', 'medium', 'tall', 'specimen')
+* `canopy_width_ft`: FLOAT
+* `foliage_color_family`: ENUM('green', 'blue-green', 'chartreuse', 'burgundy', 'variegated')
+* `flower_color_family`: ENUM('white', 'yellow', 'orange', 'red', 'pink', 'blue', 'purple')
+* `seasons_of_interest`: ARRAY['spring', 'summer', 'fall', 'winter']
+* `texture`: ENUM('fine', 'medium', 'coarse')
+* `is_specimen`: BOOLEAN
+
+---
+
+### **2. Rule Set 1: Spacing & Placement**
+
+**Foundational viability logic:**
+
+* **R1.1 Plant Spacing:**
+  `min_distance = (A.canopy_width_ft / 2 + B.canopy_width_ft / 2) * 0.9`
+* **R1.2 Hardscape Clearance:**
+  `min_distance_from_hardscape = (canopy_width_ft / 2) + 1.0`
+* **R1.3 Structure Avoidance:**
+  `tall/specimen` plants must not be within 10 ft of structures or directly under lines
+
+---
+
+### **3. Rule Set 2: Composition & Aesthetics**
+
+**Priority-based refinement rules:**
+
+* **R2.1 Layering:**
+  Front-to-back: groundcover → short → medium → tall; specimen overrides allowed
+* **R2.2 Grouping:**
+  Non-specimen plants must be grouped in odd numbers (3, 5, 7)
+* **R2.3 Focal Points:**
+  Max one `is_specimen = TRUE` per landscape bed
+* **R2.4 Color Cohesion:**
+
+  * Max 3 flower color families per bed
+  * Avoid clashing adjacency; enforce analogous/complementary color theory
+* **R2.5 Texture Variety:**
+  5+ plant groupings must include ≥2 different textures
+
+---
+
+### **4. Rule Set 3: GNN Refinement Layer**
+
+* **Graph**
+
+  * *Nodes:* plants, hardscape, photo viewpoints
+  * *Edges:* adjacency, visibility, co-location
+* **Training Objective**
+  Trained on *Confirm & Finalize* dataset:
+
+  * *Positive:* Accepted layouts
+  * *Negative:* Deleted/moved placements
+* **Inference Workflow**
+
+  * Run Rules 1–2
+  * GNN scores arrangement (`Aesthetic_Score: 0.0–1.0`)
+  * Generate layout variations → select highest score
+
+---
+
+## **Section 10.1: Upsell Generator Logic**
+
+### **Process Flow**
+
+1. **Trigger:** After base design + risk engine complete
+
+2. **Candidate Sourcing:**
+
+   * `rate_card_items` where category ∈ (`Lighting`, `Hardscape Upgrade`, `Premium Plant`, `Water Feature`, `Maintenance Package`)
+   * Include items with `margin_percent > 0.40`
+
+3. **Contextual Filters:**
+
+   * **Project Scale Filter:**
+
+     * If quote < $2k → exclude items > $1k
+     * If quote < $10k → exclude items > $5k
+   * **Risk Filter:** exclude 'high risk' plant items
+   * **Duplication Filter:** exclude items already in BOM
+
+4. **Scoring & Ranking:**
+
+   ```
+   Rank_Score = (normalized_margin * 0.6) + (normalized_popularity * 0.4)
+   ```
+
+   * Top 3 scored candidates are selected
+
+5. **LLM Prompt (GPT-4o)**
+   **System Prompt:**
+
+   ```
+   You are YardVision Pro's expert sales assistant... (as provided)
+   ```
+
+   **User Message:** Uses project context and structured upsell items list (as provided)
+
+---
+
+## **Section 10.2: Cost Estimator Logic**
+
+### **Inputs**
+
+* `Design_BOM`
+* `tenant_rate_card`
+* `tenant_settings`
+
+  * `default_labor_rate_per_hour`
+  * `default_overhead_multiplier`
+
+### **Formulas**
+
+* **Material Cost:**
+  `SUM(quantity * base_cost)`
+* **Labor Cost:**
+  `SUM(quantity * labor_hours) * labor_rate`
+* **Subtotal:**
+  `material + labor`
+* **Final Quote:**
+  `subtotal * (1 + overhead_multiplier)`
+
+### **Output JSON Format**
+
+```json
+{
+  "baseline_quote_total": 7375.00,
+  "components": {
+    "total_material_cost": 4250.00,
+    "total_labor_cost": 1750.00,
+    "total_calculated_hours": 35.0,
+    "project_subtotal": 6000.00
+  },
+  "factors": {
+    "labor_rate_applied": 50.00,
+    "overhead_multiplier_applied": 0.25
+  }
+}
+```
+

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,34 @@
+async function postJSON(url, data) {
+    const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+    });
+    return resp.json();
+}
+
+function formHandler(formId, handler) {
+    document.getElementById(formId).addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const data = Object.fromEntries(new FormData(form).entries());
+        try {
+            const result = await handler(data);
+            document.getElementById(formId.replace('Form', 'Result')).textContent = JSON.stringify(result, null, 2);
+        } catch (err) {
+            document.getElementById(formId.replace('Form', 'Result')).textContent = err.toString();
+        }
+    });
+}
+
+formHandler('designForm', (d) => postJSON('/v1/design-jobs', { project_id: d.project_id, preview_only: d.preview_only === 'on' }));
+formHandler('statusForm', async (d) => {
+    const resp = await fetch(`/v1/design-jobs/${d.job_id}`);
+    return resp.json();
+});
+formHandler('purchaseForm', (d) => postJSON('/v1/credits/purchase', d));
+formHandler('deductForm', (d) => postJSON('/v1/credits/deduct', { tenant_id: d.tenant_id, amount: Number(d.amount) }));
+formHandler('rateForm', async (d) => {
+    const resp = await fetch(`/v1/rate-card?tenant_id=${encodeURIComponent(d.tenant_id)}`);
+    return resp.json();
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YardVision Pro UI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+    <div class="container mx-auto p-4 space-y-6">
+        <h1 class="text-3xl font-bold text-center">YardVision Pro</h1>
+
+        <section class="bg-white shadow rounded p-4">
+            <h2 class="text-xl font-semibold mb-2">Create Design Job</h2>
+            <form id="designForm" class="space-y-2">
+                <input name="project_id" placeholder="Project ID" class="border p-2 w-full" required>
+                <label class="flex items-center space-x-2">
+                    <input type="checkbox" name="preview_only" class="form-checkbox">
+                    <span>Preview Only</span>
+                </label>
+                <button class="bg-blue-500 text-white px-3 py-1 rounded" type="submit">Create</button>
+            </form>
+            <pre id="designResult" class="text-sm text-gray-600 mt-2"></pre>
+        </section>
+
+        <section class="bg-white shadow rounded p-4">
+            <h2 class="text-xl font-semibold mb-2">Check Job Status</h2>
+            <form id="statusForm" class="space-y-2">
+                <input name="job_id" placeholder="Job ID" class="border p-2 w-full" required>
+                <button class="bg-green-500 text-white px-3 py-1 rounded" type="submit">Check</button>
+            </form>
+            <pre id="statusResult" class="text-sm text-gray-600 mt-2"></pre>
+        </section>
+
+        <section class="bg-white shadow rounded p-4">
+            <h2 class="text-xl font-semibold mb-2">Purchase Credits</h2>
+            <form id="purchaseForm" class="space-y-2">
+                <input name="tenant_id" placeholder="Tenant ID" class="border p-2 w-full" required>
+                <input name="plan_id" placeholder="Plan ID (starter, pro, agency)" class="border p-2 w-full" required>
+                <button class="bg-purple-500 text-white px-3 py-1 rounded" type="submit">Purchase</button>
+            </form>
+            <pre id="purchaseResult" class="text-sm text-gray-600 mt-2"></pre>
+        </section>
+
+        <section class="bg-white shadow rounded p-4">
+            <h2 class="text-xl font-semibold mb-2">Deduct Credits</h2>
+            <form id="deductForm" class="space-y-2">
+                <input name="tenant_id" placeholder="Tenant ID" class="border p-2 w-full" required>
+                <input name="amount" type="number" placeholder="Amount" class="border p-2 w-full" required>
+                <button class="bg-red-500 text-white px-3 py-1 rounded" type="submit">Deduct</button>
+            </form>
+            <pre id="deductResult" class="text-sm text-gray-600 mt-2"></pre>
+        </section>
+
+        <section class="bg-white shadow rounded p-4">
+            <h2 class="text-xl font-semibold mb-2">Get Rate Card</h2>
+            <form id="rateForm" class="space-y-2">
+                <input name="tenant_id" placeholder="Tenant ID" class="border p-2 w-full" required>
+                <button class="bg-yellow-500 text-white px-3 py-1 rounded" type="submit">Fetch</button>
+            </form>
+            <pre id="rateResult" class="text-sm text-gray-600 mt-2"></pre>
+        </section>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- add a tiny Tailwind-based UI under `frontend/`
- serve the UI using FastAPI's static file support
- document how to open the demo UI in README
- ignore common generated files

## Testing
- `pip install -r requirements.txt`
- `python -m backend.run --host 0.0.0.0 --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_684641bc7020832087854fe46784ec9e